### PR TITLE
Add Travis build for publishing new versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,19 @@
 language: node_js
 node_js:
   - "8"
+cache:
+  directories:
+    - node_modules
+install:
+  - npm update
+script:
+  - node bin/inc_version.js
+  - npm update
+  - node bin/make_bundle.js
+after_success:
+  - npm publish
+branches:
+  only:
+    - master
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,13 @@ cache:
     - node_modules
 script:
   - node bin/latest_version.js
-after_success:
   - npm update
   - node bin/make_bundle.js
-  - npm publish
-branches:
-  only:
-    - master
+deploy:
+  provider: npm
+  email: ""
+  api_key: ""
+  on:
+    branch: master
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ cache:
     - node_modules
 script:
   - node bin/latest_version.js
+after_success:
   - npm update
   - node bin/make_bundle.js
-after_success:
   - npm publish
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ node_js:
 cache:
   directories:
     - node_modules
-install:
-  - npm update
 script:
-  - node bin/inc_version.js
+  - node bin/latest_version.js
   - npm update
   - node bin/make_bundle.js
 after_success:

--- a/bin/latest_version.js
+++ b/bin/latest_version.js
@@ -13,7 +13,7 @@ api.getdetails('rxjs', rxjs => {
 
     if (latest(rxjs) == latest(systemBundle)) {
       console.error("At most recent version");
-      process.exit(51);
+      process.exit(0);
     }
 
     const lastVersion = latest(rxjs);

--- a/bin/latest_version.js
+++ b/bin/latest_version.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const api = require('api-npm');
+
+const packageFileName = '../package.json';
+const package = require(packageFileName);
+
+const matchVersion = require('./match_version');
+
+const latest = package => package['dist-tags'].latest;
+
+api.getdetails('rxjs', rxjs => {
+  api.getdetails(package.name, systemBundle => {
+
+    if (latest(rxjs) == latest(systemBundle)) {
+      console.error("At most recent version");
+      process.exit(51);
+    }
+
+    const lastVersion = latest(rxjs);
+    console.log("Writing package.json with latest version", lastVersion);
+    package.devDependencies.rxjs = lastVersion;
+    fs.writeFileSync(packageFileName, JSON.stringify(package, null, 2) + '\n');
+
+    matchVersion(err => {
+      if (err) {
+        console.error(err);
+        process.exit(60);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Thanks for creating this bundle, it is pretty handy :tada: 

This PR adds a Travis build to make publishing new bundle versions automatic. If [set up as a cron job](https://docs.travis-ci.com/user/cron-jobs/) and [provided with an NPM token](https://docs.travis-ci.com/user/deployment/npm/#NPM-auth-token), this build should be able to track the RxJs releases without supervision.